### PR TITLE
Fix "!" mark-as-spam shortcut on non-QWERTY (AZERTY) keyboards

### DIFF
--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -287,7 +287,7 @@ export function useKeyboard(conversations: Conversation[], composeRef: React.Ref
       }
 
       // Shift+! — Mark as Spam (with confirmation)
-      if (e.key === '!' && e.shiftKey) {
+      if (e.key === '!' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         const conv = store.selectedConversationId
           ? convs.find((c) => c.id === store.selectedConversationId)

--- a/test/regressions/56-azerty-spam-shortcut.dom.test.tsx
+++ b/test/regressions/56-azerty-spam-shortcut.dom.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import '../dom-setup';
+
+import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { useKeyboard } from '@/hooks/useKeyboard';
+import { useUIStore } from '@/store/ui-store';
+import { makeConversation } from '../fixtures/factories';
+
+const mockActions = {
+  archiveConversation: vi.fn(),
+  moveToOther: vi.fn(),
+  moveToFocused: vi.fn(),
+  markRead: vi.fn(),
+  markUnread: vi.fn(),
+  starConversation: vi.fn(),
+};
+
+vi.mock('@/hooks/useOptimisticAction', () => ({
+  useOptimisticAction: () => mockActions,
+}));
+
+vi.mock('@/lib/bridge', () => ({
+  sendBridgeMessage: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('@/db/database', () => ({
+  db: { profiles: { get: vi.fn().mockResolvedValue(undefined) } },
+}));
+
+function pressOn(el: HTMLElement | Window, key: string, mods: Partial<KeyboardEventInit> = {}) {
+  const ev = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...mods });
+  (el instanceof Window ? el.document.body : el).dispatchEvent(ev);
+  return ev;
+}
+
+describe('useKeyboard "!" mark-as-spam shortcut (layout independence)', () => {
+  const conversations = [makeConversation({ id: '2-conv-spam-1' }), makeConversation({ id: '2-conv-spam-2' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({
+      selectedIndex: 0,
+      selectedConversationId: '2-conv-spam-1',
+      inboxTab: 'focused',
+      paletteOpen: false,
+      shortcutOverlayOpen: false,
+      searchQuery: '',
+      deleteConfirmId: null,
+      spamConfirmId: null,
+      aiSetupOpen: false,
+      lightboxImageUrl: null,
+      composeActive: false,
+      composeNewActive: false,
+    });
+  });
+
+  function renderKeyboard() {
+    return renderHook(() => useKeyboard(conversations, createRef<HTMLTextAreaElement>()));
+  }
+
+  it('AZERTY: bare "!" (no Shift) opens the spam confirmation', () => {
+    renderKeyboard();
+    const ev = pressOn(window, '!');
+    expect(useUIStore.getState().spamConfirmId).toBe('2-conv-spam-1');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('QWERTY: Shift+"!" still opens the spam confirmation', () => {
+    renderKeyboard();
+    pressOn(window, '!', { shiftKey: true });
+    expect(useUIStore.getState().spamConfirmId).toBe('2-conv-spam-1');
+  });
+
+  it('Cmd+! / Ctrl+! are not hijacked', () => {
+    renderKeyboard();
+    const cmd = pressOn(window, '!', { metaKey: true });
+    const ctrl = pressOn(window, '!', { ctrlKey: true });
+    expect(useUIStore.getState().spamConfirmId).toBeNull();
+    expect(cmd.defaultPrevented).toBe(false);
+    expect(ctrl.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3 — pressing `!` to mark a conversation as spam does nothing on AZERTY keyboards.

The handler in `src/hooks/useKeyboard.ts` required `e.shiftKey` alongside `e.key === '!'`:

```ts
if (e.key === '!' && e.shiftKey) {
```

On AZERTY (and other non-QWERTY layouts) `!` is a direct, unshifted key, so `e.shiftKey` is `false` even though `e.key` is correctly `'!'`. The shortcut therefore never fired for those users, while QWERTY users (who type `Shift+1`) were unaffected.

## Fix

`e.key` is already layout-aware and unambiguously identifies the `!` character regardless of which physical key produced it, so the `shiftKey` guard was redundant and layout-hostile. The handler now matches on `e.key` only, keeping the `!metaKey`/`!ctrlKey` guard for consistency with the other single-key shortcuts so browser combos aren't hijacked:

```ts
if (e.key === '!' && !e.metaKey && !e.ctrlKey) {
```

The `shift: true` metadata in `shortcutDefinitions` is left untouched — it only drives the display label in the shortcuts overlay (`⇧!`), not the runtime check.

## Testing

- Added `test/regressions/56-azerty-spam-shortcut.dom.test.tsx` covering:
  - AZERTY: bare `!` (no Shift) opens the spam confirmation
  - QWERTY: `Shift+!` still opens the spam confirmation
  - `Cmd+!` / `Ctrl+!` are not hijacked
- Full suite green: **551 tests passing** (`npx vitest run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)