### PR TITLE
Fix "!" and "?" shortcuts on non-QWERTY (AZERTY) keyboards

### DIFF
--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -192,8 +192,8 @@ export function useKeyboard(conversations: Conversation[], composeRef: React.Ref
         return;
       }
 
-      // ? — Show shortcuts
-      if (e.key === '?' && e.shiftKey) {
+      // ? — Show shortcuts (no shiftKey guard — e.key is layout-aware)
+      if (e.key === '?' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         store.toggleShortcutOverlay();
         return;
@@ -286,7 +286,7 @@ export function useKeyboard(conversations: Conversation[], composeRef: React.Ref
         return;
       }
 
-      // Shift+! — Mark as Spam (with confirmation)
+      // ! — Mark as Spam (with confirmation; no shiftKey guard — e.key is layout-aware)
       if (e.key === '!' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         const conv = store.selectedConversationId

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -287,7 +287,7 @@ export function useKeyboard(conversations: Conversation[], composeRef: React.Ref
       }
 
       // Shift+! — Mark as Spam (with confirmation)
-      if (e.key === '!' && e.shiftKey) {
+      if (e.key === '!' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         const conv = store.selectedConversationId
           ? convs.find((c) => c.id === store.selectedConversationId)

--- a/test/regressions/56-azerty-keyboard-shortcuts.dom.test.tsx
+++ b/test/regressions/56-azerty-keyboard-shortcuts.dom.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+// Regression: keyboard shortcuts that produce shifted characters on QWERTY
+// (like "!" = Shift+1, "?" = Shift+/) must not require e.shiftKey, because
+// on other layouts (AZERTY, etc.) these are direct, unshifted keys.
+// See: https://github.com/grinich/inflow/issues/3
 import '../dom-setup';
 
 import { renderHook } from '@testing-library/react';
@@ -77,6 +81,54 @@ describe('useKeyboard "!" mark-as-spam shortcut (layout independence)', () => {
     const cmd = pressOn(window, '!', { metaKey: true });
     const ctrl = pressOn(window, '!', { ctrlKey: true });
     expect(useUIStore.getState().spamConfirmId).toBeNull();
+    expect(cmd.defaultPrevented).toBe(false);
+    expect(ctrl.defaultPrevented).toBe(false);
+  });
+});
+
+describe('useKeyboard "?" show-shortcuts shortcut (layout independence)', () => {
+  const conversations = [makeConversation({ id: '2-conv-qs-1' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({
+      selectedIndex: 0,
+      selectedConversationId: '2-conv-qs-1',
+      inboxTab: 'focused',
+      paletteOpen: false,
+      shortcutOverlayOpen: false,
+      searchQuery: '',
+      deleteConfirmId: null,
+      spamConfirmId: null,
+      aiSetupOpen: false,
+      lightboxImageUrl: null,
+      composeActive: false,
+      composeNewActive: false,
+    });
+  });
+
+  function renderKeyboard() {
+    return renderHook(() => useKeyboard(conversations, createRef<HTMLTextAreaElement>()));
+  }
+
+  it('bare "?" (no Shift) toggles the shortcut overlay', () => {
+    renderKeyboard();
+    const ev = pressOn(window, '?');
+    expect(useUIStore.getState().shortcutOverlayOpen).toBe(true);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('Shift+"?" still toggles the shortcut overlay', () => {
+    renderKeyboard();
+    pressOn(window, '?', { shiftKey: true });
+    expect(useUIStore.getState().shortcutOverlayOpen).toBe(true);
+  });
+
+  it('Cmd+? / Ctrl+? are not hijacked', () => {
+    renderKeyboard();
+    const cmd = pressOn(window, '?', { metaKey: true });
+    const ctrl = pressOn(window, '?', { ctrlKey: true });
+    expect(useUIStore.getState().shortcutOverlayOpen).toBe(false);
     expect(cmd.defaultPrevented).toBe(false);
     expect(ctrl.defaultPrevented).toBe(false);
   });

--- a/test/regressions/56-azerty-spam-shortcut.dom.test.tsx
+++ b/test/regressions/56-azerty-spam-shortcut.dom.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import '../dom-setup';
+
+import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { useKeyboard } from '@/hooks/useKeyboard';
+import { useUIStore } from '@/store/ui-store';
+import { makeConversation } from '../fixtures/factories';
+
+const mockActions = {
+  archiveConversation: vi.fn(),
+  moveToOther: vi.fn(),
+  moveToFocused: vi.fn(),
+  markRead: vi.fn(),
+  markUnread: vi.fn(),
+  starConversation: vi.fn(),
+};
+
+vi.mock('@/hooks/useOptimisticAction', () => ({
+  useOptimisticAction: () => mockActions,
+}));
+
+vi.mock('@/lib/bridge', () => ({
+  sendBridgeMessage: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('@/db/database', () => ({
+  db: { profiles: { get: vi.fn().mockResolvedValue(undefined) } },
+}));
+
+function pressOn(el: HTMLElement | Window, key: string, mods: Partial<KeyboardEventInit> = {}) {
+  const ev = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...mods });
+  (el instanceof Window ? el.document.body : el).dispatchEvent(ev);
+  return ev;
+}
+
+describe('useKeyboard "!" mark-as-spam shortcut (layout independence)', () => {
+  const conversations = [makeConversation({ id: '2-conv-spam-1' }), makeConversation({ id: '2-conv-spam-2' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({
+      selectedIndex: 0,
+      selectedConversationId: '2-conv-spam-1',
+      inboxTab: 'focused',
+      paletteOpen: false,
+      shortcutOverlayOpen: false,
+      searchQuery: '',
+      deleteConfirmId: null,
+      spamConfirmId: null,
+      aiSetupOpen: false,
+      lightboxImageUrl: null,
+      composeActive: false,
+      composeNewActive: false,
+    });
+  });
+
+  function renderKeyboard() {
+    return renderHook(() => useKeyboard(conversations, createRef<HTMLTextAreaElement>()));
+  }
+
+  it('AZERTY: bare "!" (no Shift) opens the spam confirmation', () => {
+    renderKeyboard();
+    const ev = pressOn(window, '!');
+    expect(useUIStore.getState().spamConfirmId).toBe('2-conv-spam-1');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('QWERTY: Shift+"!" still opens the spam confirmation', () => {
+    renderKeyboard();
+    pressOn(window, '!', { shiftKey: true });
+    expect(useUIStore.getState().spamConfirmId).toBe('2-conv-spam-1');
+  });
+
+  it('Cmd+! / Ctrl+! are not hijacked', () => {
+    renderKeyboard();
+    const cmd = pressOn(window, '!', { metaKey: true });
+    const ctrl = pressOn(window, '!', { ctrlKey: true });
+    expect(useUIStore.getState().spamConfirmId).toBeNull();
+    expect(cmd.defaultPrevented).toBe(false);
+    expect(ctrl.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Builds on @qchuchu's fix from #4 (closes #3) and addresses remaining nits:

- **`!` shortcut**: applies the `e.key`-only check from PR #4 (drop `e.shiftKey` guard), updates the stale comment
- **`?` shortcut**: same bug — `e.key === '?' && e.shiftKey` fails on layouts where `?` is a direct key. Fixed to `!e.metaKey && !e.ctrlKey` for consistency
- **Test file**: renamed `56-azerty-spam-shortcut` → `56-azerty-keyboard-shortcuts`, added 3 tests for `?` (bare key, Shift+key, Cmd/Ctrl guards)

Rebased onto current main. **558 tests passing**.

## Test plan

- [x] AZERTY: bare `!` opens spam confirmation
- [x] QWERTY: `Shift+!` still opens spam confirmation
- [x] `Cmd+!` / `Ctrl+!` are not hijacked
- [x] Bare `?` toggles shortcut overlay
- [x] `Shift+?` still toggles shortcut overlay
- [x] `Cmd+?` / `Ctrl+?` are not hijacked
- [x] Full suite green (558 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)